### PR TITLE
Added strong regexp for email validation

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -159,7 +159,7 @@ Devise.setup do |config|
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly
   # to give user feedback and not to assert the e-mail validity.
-  config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+  config.email_regexp = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/
 
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this


### PR DESCRIPTION
Added stronger regexp to the email validation, since the one we had was letting emails like ricardo@banana to pass. 
\A[\w+-.]+@[a-z\d-.]+.[a-z]+\z
This is the expression we have now, feel free to test it on rubular.
